### PR TITLE
Add scroll to top functionality on Product page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { AllRoutes } from "./routes/AllRoutes";
-import { Footer, Header } from "./components";
+import { Footer, Header,ScrollToTop } from "./components";
 
 function App() {
   return (

--- a/src/components/Other/ScrolltoTop.js
+++ b/src/components/Other/ScrolltoTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export { Header } from "../components/Layouts/Header";
 export { Footer } from "../components/Layouts/Footer";
 export { ProductCard } from "./Elements/ProductCard"
+export { ScrollToTop } from "./Other/ScrollToTop"

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { BrowserRouter as Router } from "react-router-dom";
+import { ScrollToTop } from "./components";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <Router>
+      <ScrollToTop/>
       <App />
     </Router>
   </React.StrictMode>


### PR DESCRIPTION
This PR introduces a "Scroll to Top". Whenever users navigate to or land on the Product page, the window will automatically scroll to the top. This ensures that users start their viewing experience from the beginning of the page, enhancing usability and ensuring a consistent user experience.